### PR TITLE
Add variable area argument to ca_biggeom_blocks() function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: caladaptr
 Type: Package
 Title: Import Climate Data from Cal-Adapt via the API
-Version: 0.6.8
-Date: 2022-11-29
+Version: 0.6.9
+Date: 2025-01-13
 Authors@R: c(person(given = "Andy",
                   family = "Lyons", 
                   role = c("aut", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,7 @@ Imports:
     units,
     utils,
     zip
-RoxygenNote: 7.2.1
+RoxygenNote: 7.3.2
 Suggests: 
     chillR,
     cubelyr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# caladaptr 0.6.9 (2025-01-13)
+
+* add variale `block_area_mi2` argument to `ca_biggeom_blocks`
+
 # caladaptr 0.6.8 (2022-11-29)
 
 * `ca_getvals_db()`, `ca_getvals_tbl()`: trapped an error where a preset AOI falls outside the LOCA grid (e.g., Farallon Islands HUC10 watershed)

--- a/R/ca_biggeom_blocks.R
+++ b/R/ca_biggeom_blocks.R
@@ -31,7 +31,7 @@
 #'
 #'
 #' }
-ca_biggeom_blocks <- function(x, block_area_mi2 = 10000) {
+ca_biggeom_blocks <- function(x, block_area_mi2 = 18000) { # 18000 mi2 ~= 46,600 km2
 
   ## Define the target area and width in m2
   target_area_m2 <- set_units(block_area_mi2, "mi^2") %>% set_units("m^2") ##  51,800 km2

--- a/R/ca_biggeom_blocks.R
+++ b/R/ca_biggeom_blocks.R
@@ -34,7 +34,7 @@
 ca_biggeom_blocks <- function(x, block_area_mi2 = 18000) { # 18000 mi2 ~= 46,600 km2
 
   ## Define the target area and width in m2
-  target_area_m2 <- set_units(block_area_mi2, "mi^2") %>% set_units("m^2") ##  51,800 km2
+  target_area_m2 <- set_units(block_area_mi2, "mi^2") %>% set_units("m^2")
   target_width_m <- target_area_m2 %>% sqrt() %>% round()         ## about 228 km
 
   ## We'll use web mercator (units = m)

--- a/R/ca_biggeom_blocks.R
+++ b/R/ca_biggeom_blocks.R
@@ -1,6 +1,8 @@
 #' Split a large geom into blocks small enough to ask the API for rasters
 #'
 #' @param x A big geom
+#' @param block_area_mi2 Numeric area in square miles for each block.
+#'   Smaller values => more sub-polygons. Default = 10,000.
 #'
 #' @details The Cal-Adapt API has a limit of around 20,000 mi^2 as the maximum area for which you can download a raster.
 #' This function will take a sf data frame larger than this and return blocks that cover the same extent. Subsequently you can
@@ -29,11 +31,10 @@
 #'
 #'
 #' }
-
-ca_biggeom_blocks <- function(x) {
+ca_biggeom_blocks <- function(x, block_area_m2 = 10000) {
 
   ## Define the target area and width in m2
-  target_area_m2 <- set_units(20000, "mi^2") %>% set_units("m^2") ##  51,800 km2
+  target_area_m2 <- set_units(block_area_m2, "mi^2") %>% set_units("m^2") ##  51,800 km2
   target_width_m <- target_area_m2 %>% sqrt() %>% round()         ## about 228 km
 
   ## We'll use web mercator (units = m)

--- a/R/ca_biggeom_blocks.R
+++ b/R/ca_biggeom_blocks.R
@@ -34,7 +34,7 @@
 ca_biggeom_blocks <- function(x, block_area_mi2 = 10000) {
 
   ## Define the target area and width in m2
-  target_area_m2 <- set_units(block_area_m2, "mi^2") %>% set_units("m^2") ##  51,800 km2
+  target_area_m2 <- set_units(block_area_mi2, "mi^2") %>% set_units("m^2") ##  51,800 km2
   target_width_m <- target_area_m2 %>% sqrt() %>% round()         ## about 228 km
 
   ## We'll use web mercator (units = m)

--- a/R/ca_biggeom_blocks.R
+++ b/R/ca_biggeom_blocks.R
@@ -2,7 +2,7 @@
 #'
 #' @param x A big geom
 #' @param block_area_mi2 Numeric area in square miles for each block.
-#'   Smaller values => more sub-polygons. Default = 10,000.
+#'   Smaller values => more sub-polygons. Default = 18,000. API limit is 20k. 
 #'
 #' @details The Cal-Adapt API has a limit of around 20,000 mi^2 as the maximum area for which you can download a raster.
 #' This function will take a sf data frame larger than this and return blocks that cover the same extent. Subsequently you can

--- a/R/ca_biggeom_blocks.R
+++ b/R/ca_biggeom_blocks.R
@@ -31,7 +31,7 @@
 #'
 #'
 #' }
-ca_biggeom_blocks <- function(x, block_area_m2 = 10000) {
+ca_biggeom_blocks <- function(x, block_area_mi2 = 10000) {
 
   ## Define the target area and width in m2
   target_area_m2 <- set_units(block_area_m2, "mi^2") %>% set_units("m^2") ##  51,800 km2

--- a/man/ca_biggeom_blocks.Rd
+++ b/man/ca_biggeom_blocks.Rd
@@ -4,10 +4,13 @@
 \alias{ca_biggeom_blocks}
 \title{Split a large geom into blocks small enough to ask the API for rasters}
 \usage{
-ca_biggeom_blocks(x)
+ca_biggeom_blocks(x, block_area_mi2 = 18000)
 }
 \arguments{
 \item{x}{A big geom}
+
+\item{block_area_mi2}{Numeric area in square miles for each block.
+Smaller values => more sub-polygons. Default = 18,000. API limit is 20k.}
 }
 \value{
 A polygon simple feature data frame covering the same extent as \code{x}


### PR DESCRIPTION
In testing, it appears that the limit of 20,000 mi^2 is too large, and the API requests failed.

I added an argument to the `ca_biggeom_blocks()` function with a default `block_area_mi2`, and set the default area to 10,000 mi^2. This a) makes sure the default is << limit and b) provides the option of varying the block area.